### PR TITLE
fix(Chart, Price): fetchCoinHistory api의 해당 코인 정보 X -> 경고 문구 생성

### DIFF
--- a/src/Components/Error404.tsx
+++ b/src/Components/Error404.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+const Title = styled.h2`
+  font-size: 43px;
+  color: red;
+  font-weight: bold;
+`;
+
+function Error404() {
+  return (
+    <Title>Sorry! The information of this Coin is not in the API!!!</Title>
+  );
+}
+
+export default Error404;

--- a/src/routes/Chart.tsx
+++ b/src/routes/Chart.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "react-query";
 import { fetchCoinHistory } from "../api";
 import ApexChart from "react-apexcharts";
+import Error404 from "../Components/Error404";
 
 interface ChartProps {
   coinId: string;
@@ -16,17 +17,19 @@ export interface IHistorical {
   volume: string;
   market_cap: number;
 }
+
 function Chart({ coinId }: ChartProps) {
   const { isLoading, data } = useQuery<IHistorical[]>(
     ["ohlcv", coinId],
     () => fetchCoinHistory(coinId),
     { refetchInterval: 10000 }
   );
+
   return (
     <div>
       {isLoading ? (
         "Loading Chart..."
-      ) : (
+      ) : data?.length ? (
         <ApexChart
           type="line"
           series={[
@@ -77,6 +80,8 @@ function Chart({ coinId }: ChartProps) {
             },
           }}
         />
+      ) : (
+        <Error404 />
       )}
     </div>
   );

--- a/src/routes/Coin.tsx
+++ b/src/routes/Coin.tsx
@@ -156,10 +156,10 @@ function Coin() {
   );
   const { isLoading: tickersLoading, data: tickersData } = useQuery<priceData>(
     ["tickers", coinId],
-    () => fetchCoinTickers(coinId),
-    {
-      refetchInterval: 5000,
-    }
+    () => fetchCoinTickers(coinId)
+    // {
+    //   refetchInterval: 5000,
+    // }
   );
   const loading = infoLoading || tickersLoading;
   return (

--- a/src/routes/Coins.tsx
+++ b/src/routes/Coins.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "react-query";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { fetchCoins } from "../api";
-import { HomeBtn } from "../Components/HomeBtn";
 
 const Container = styled.div`
   padding: 0px 20px;
@@ -63,9 +62,8 @@ interface ICoin {
   is_active: boolean;
   type: string;
 }
-interface ICoinsProps {}
 
-function Coins({}) {
+function Coins() {
   const { isLoading, data } = useQuery<ICoin[]>("allCoins", fetchCoins);
   return (
     <Container>

--- a/src/routes/Price.tsx
+++ b/src/routes/Price.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "react-query";
 import { fetchCoinHistory } from "../api";
 import { IHistorical } from "./Chart";
 import ApexChart from "react-apexcharts";
+import Error404 from "../Components/Error404";
 
 interface PriceProps {
   coinId: string;
@@ -17,7 +18,7 @@ function Price({ coinId }: PriceProps) {
     <div>
       {isLoading ? (
         "Loading Chart..."
-      ) : (
+      ) : data?.length ? (
         <ApexChart
           type="candlestick"
           height={350}
@@ -67,15 +68,11 @@ function Price({ coinId }: PriceProps) {
             },
           ]}
         />
+      ) : (
+        <Error404 />
       )}
     </div>
   );
 }
 
-// data: [
-//   {
-//     x: new Date(1538778600000),
-//     y: [6629.81, 6650.5, 6623.04, 6633.33],
-//   },
-// ],
 export default Price;


### PR DESCRIPTION
원인: 코인에 대한 정보가 없을 경우 반환되는 객체를 map 함수를 잘못 이용
fetchCoinHistory api의 해당 코인 정보 없을 경우 {error: string} 발생 정상적으로 받을 경우 [{}, {}, ...] 받음

해결: 삼항 연산자를 사용하여 배열은 length 함수를 사용 할 수 있는 점을 활용
404 에러는 콘솔 화면에 뿌려주고 ui에는 경고 문구 커스텀 함